### PR TITLE
Fix exception type

### DIFF
--- a/Model/Fintecture.php
+++ b/Model/Fintecture.php
@@ -683,7 +683,7 @@ class Fintecture extends AbstractMethod
                     'response' => $apiResponse->errorMsg
                 ]);
                 $this->checkoutSession->restoreQuote();
-                throw new LocalizedException($apiResponse->errorMsg);
+                throw new Exception($apiResponse->errorMsg);
             }
         } catch (Exception $e) {
             $this->fintectureLogger->error('Error', [


### PR DESCRIPTION
If the api connexion fails a string is passed to  LocalizedException which result to the following error :

report.CRITICAL: TypeError: Magento\Framework\Exception\LocalizedException::__construct(): Argument #1 ($phrase) must be of type Magento\Framework\Phrase, string given, called in /app/vendor/fintecture/payment/Model/Fintecture.php on line 686 and defined in /app/vendor/magento/framework/Exception/LocalizedException.php:36
Stack trace:
#0 /app/vendor/fintecture/payment/Model/Fintecture.php(686): Magento\Framework\Exception\LocalizedException->__construct('Error - Status ...')
#1 /app/vendor/fintecture/payment/Controller/Standard/Redirect.php(46): Fintecture\Payment\Model\Fintecture->getPaymentRedirectUrl()
#2 /app/vendor/magento/framework/Interception/Interceptor.php(58): Fintecture\Payment\Controller\Standard\Redirect->execute()

Two way possible to fix, throw a simple Exception ( this is what is done in this PR ) or pass a Phrase instance to the LocalizedException
